### PR TITLE
Guide accuracy fixes, quiet hours, quote centering, new review

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -165,7 +165,7 @@ export default function ContactPage() {
           {/* Subtle gradient so the overlay has contrast without killing the photo */}
           <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />
 
-          <div className="absolute inset-0 flex items-end justify-center pb-8 px-6 pointer-events-none">
+          <div className="absolute inset-0 flex items-center justify-center px-6 pointer-events-none">
             <div
               className="rounded-xl px-5 py-4 sm:px-8 sm:py-6 text-center max-w-[85%] sm:max-w-lg pointer-events-auto"
               style={{

--- a/src/data/guide-content.ts
+++ b/src/data/guide-content.ts
@@ -114,7 +114,8 @@ export const guideSections: GuideSection[] = [
 
       { text: "Bedroom", heading: true },
       { text: "Extra pillows and blankets: wardrobe's top shelves." },
-      { text: "Beach blankets (subject to availability): the two white ones with gray symbols (rough, thick) are for the beach. Blue or dark gray ones are bed covers, so keep them in the house.", highlight: true },
+      { text: "Beach blankets (subject to availability): use common sense to tell beach blankets apart from bed covers, and keep the bed covers in the house.", highlight: true },
+      { text: "We don't supply beach towels. Please don't take the bathroom towels to the beach, they should stay in the house.", highlight: true },
       { text: "Hair dryer and clothes iron: wardrobe's bottom right shelf." },
       { text: "Clothes dryer, ironing board and vacuum cleaner: behind the door." },
       { text: "Beach bag and other beach accessories: subject to availability, as items can move around between stays. Let us know if something you need for the beach isn't there.", highlight: true },

--- a/src/data/guide-content.ts
+++ b/src/data/guide-content.ts
@@ -114,7 +114,7 @@ export const guideSections: GuideSection[] = [
 
       { text: "Bedroom", heading: true },
       { text: "Extra pillows and blankets: wardrobe's top shelves." },
-      { text: "Beach blankets (subject to availability): the two white ones with gray symbols (rough, thick) are for the beach. Blue or dark gray ones are bed covers — keep them in the house.", highlight: true },
+      { text: "Beach blankets (subject to availability): the two white ones with gray symbols (rough, thick) are for the beach. Blue or dark gray ones are bed covers, so keep them in the house.", highlight: true },
       { text: "Hair dryer and clothes iron: wardrobe's bottom right shelf." },
       { text: "Clothes dryer, ironing board and vacuum cleaner: behind the door." },
       { text: "Beach bag and other beach accessories: subject to availability, as items can move around between stays. Let us know if something you need for the beach isn't there.", highlight: true },

--- a/src/data/guide-content.ts
+++ b/src/data/guide-content.ts
@@ -114,11 +114,10 @@ export const guideSections: GuideSection[] = [
 
       { text: "Bedroom", heading: true },
       { text: "Extra pillows and blankets: wardrobe's top shelves." },
-      { text: "Beach blankets (subject to availability): use common sense to tell beach blankets apart from bed covers, and keep the bed covers in the house.", highlight: true },
-      { text: "We don't supply beach towels. Please don't take the bathroom towels to the beach, they should stay in the house.", highlight: true },
+      { text: "Beach blankets and bag: subject to availability, as items can move around between stays. Use common sense to tell beach blankets apart from bed covers." },
+      { text: "We don't supply beach towels, so please don't take the bathroom towels to the beach. They should stay in the house.", highlight: true },
       { text: "Hair dryer and clothes iron: wardrobe's bottom right shelf." },
       { text: "Clothes dryer, ironing board and vacuum cleaner: behind the door." },
-      { text: "Beach bag and other beach accessories: subject to availability, as items can move around between stays. Let us know if something you need for the beach isn't there.", highlight: true },
     ],
   },
 ];

--- a/src/data/guide-content.ts
+++ b/src/data/guide-content.ts
@@ -61,7 +61,8 @@ export const guideSections: GuideSection[] = [
     items: [
       { text: "Shower & Towels", heading: true },
       { text: "After showering: open the bathroom window and crack open the bathroom door." },
-      { text: "Body & face towels will be left on the bed. Beach towels are in the bedroom wardrobe, right middle shelf." },
+      { text: "Body & face towels will be left on the bed." },
+      { text: "If an essential item seems to be missing, it's most likely with our cleaner for washing/drying. Just let us know and we'll sort it out.", highlight: true },
 
       { text: "Cleaning Essentials", heading: true },
       { text: "Wash dishes before leaving." },
@@ -74,7 +75,7 @@ export const guideSections: GuideSection[] = [
     emoji: "📜",
     title: "House Rules",
     items: [
-      { text: "Quiet hours: 10 PM – 8 AM 🤫", highlight: true },
+      { text: "Quiet hours: 9 PM – 8 AM 🤫", highlight: true },
       { text: "No parties.", highlight: true },
       { text: "No extra guests.", highlight: true },
       { text: "No pets.", highlight: true },
@@ -113,9 +114,10 @@ export const guideSections: GuideSection[] = [
 
       { text: "Bedroom", heading: true },
       { text: "Extra pillows and blankets: wardrobe's top shelves." },
-      { text: "Beach blankets: the two white ones with gray symbols (rough, thick) are for the beach. Blue or dark gray ones are bed covers — keep them in the house.", highlight: true },
-      { text: "Hair dryer, clothes iron and beach accessories: wardrobe's bottom right shelf." },
-      { text: "Clothes dryer, ironing board, vacuum cleaner and beach bag: behind the door." },
+      { text: "Beach blankets (subject to availability): the two white ones with gray symbols (rough, thick) are for the beach. Blue or dark gray ones are bed covers — keep them in the house.", highlight: true },
+      { text: "Hair dryer and clothes iron: wardrobe's bottom right shelf." },
+      { text: "Clothes dryer, ironing board and vacuum cleaner: behind the door." },
+      { text: "Beach bag and other beach accessories: subject to availability, as items can move around between stays. Let us know if something you need for the beach isn't there.", highlight: true },
     ],
   },
 ];

--- a/src/data/legal-content.ts
+++ b/src/data/legal-content.ts
@@ -95,7 +95,7 @@ export const privacyPolicy: LegalPage = {
 
 export const termsAndConditions: LegalPage = {
   title: "Terms & Conditions",
-  lastUpdated: "March 2026",
+  lastUpdated: "July 2026",
   sections: [
     {
       heading: "About This Document",
@@ -109,7 +109,7 @@ export const termsAndConditions: LegalPage = {
     {
       heading: "House Rules",
       body: [
-        "Quiet hours are 22:00 to 08:00. The property is in a residential area, so please be considerate of neighbours.",
+        "Quiet hours are 21:00 to 08:00. The property is in a residential area, so please be considerate of neighbours.",
         "Smoking is permitted on the terrace only. Smoking anywhere inside the apartment will incur a €200 cleaning fee.",
         "No pets are permitted.",
         "No parties or gatherings beyond the registered guest occupancy.",

--- a/src/data/listing-content.ts
+++ b/src/data/listing-content.ts
@@ -115,4 +115,9 @@ export const reviews: Review[] = [
       "Everything was just perfect - great location, top-notch service, and the place was super clean and fully equipped, exactly like the photos. Really made my vacation extra special, highly recommended! Honestly, I tried to find something I didn't like - but I couldn't!",
     author: "Yonatan H.K.",
   },
+  {
+    quote:
+      "A wonderful, clean and modern apartment with a large terrace, located about 40 minutes from the airport by car. The apartment has everything needed for a comfortable stay, cooking, and beach trips. We were pleasantly surprised to find a cooler bag and an ice pack for keeping drinks cold. The bed deserves a special mention – it is large, very comfortable, and has an excellent mattress. We slept wonderfully throughout our stay...",
+    author: "Elena T.",
+  },
 ];


### PR DESCRIPTION
## Summary
- Contact page quote overlay is now vertically centered on its photo instead of pinned to the bottom (mobile and desktop share the same fix)
- Guide no longer claims beach towels are supplied (they aren't) or points to a fixed shelf for beach bag/accessories — those move between stays, so they're now marked "subject to availability" with an ask to flag if something's missing
- Added a note in the guide: if an essential seems missing, it's most likely with the cleaner for washing, let us know and we'll sort it
- Quiet hours moved an hour earlier, 9 PM to 8 AM, updated in both the guide and the Terms & Conditions (T&C `lastUpdated` bumped to July 2026 accordingly)
- Added Elena T.'s guest review to the listing page carousel

## Test plan
- [x] `/contact`: quote card sits centered vertically on the photo, on both a mobile viewport and desktop width
- [x] `/guide`: bathroom section shows towels-on-bed line and the new missing-essentials note; house rules shows "9 PM – 8 AM"; handy extras/bedroom shows the reworded beach blanket/accessories lines with no beach-towel or fixed-shelf claims
- [x] `/terms`: quiet hours reads "21:00 to 08:00" and the last-updated date reads July 2026
- [x] `/listing`: reviews carousel includes the new Elena T. card and still autoplays/swipes correctly with 7 entries
- [x] `bun run build` passes clean (already verified locally)